### PR TITLE
Don't retry on 2xx status codes.

### DIFF
--- a/BuildPublishLocal.ps1
+++ b/BuildPublishLocal.ps1
@@ -1,0 +1,31 @@
+#Requires -Version 5.0
+
+Begin {
+    $ErrorActionPreference = "stop"
+}
+
+Process {
+    function Exec([scriptblock]$Command) {
+        & $Command
+        if ($LASTEXITCODE -ne 0) {
+            throw ("An error occurred while executing command: {0}" -f $Command)
+        }
+    }
+    
+    $workingDir = Join-Path $PSScriptRoot "src"
+    $outputDir = Join-Path $PSScriptRoot ".output"
+    $nupkgsPath = Join-Path $outputDir "*.nupkg"
+
+    try {
+        Push-Location $workingDir
+        Remove-Item $outputDir -Force -Recurse -ErrorAction SilentlyContinue
+    
+        Exec { & dotnet clean -c Release }
+        Exec { & dotnet build -c Release }
+        Exec { & dotnet test  -c Release --results-directory "$outputDir" --no-restore -l "trx" -l "console;verbosity=detailed" }
+        Exec { & docker build --file .\EventGridEmulator\Dockerfile -t workleap/eventgridemulator:tonesandtones-81 . }
+    }
+    finally {
+        Pop-Location
+    }
+}

--- a/src/EventGridEmulator/Network/SubscriberConstants.cs
+++ b/src/EventGridEmulator/Network/SubscriberConstants.cs
@@ -12,6 +12,16 @@ internal static class SubscriberConstants
     {
         // Of course we let HTTP 200 pass through
         HttpStatusCode.OK,
+        //...and all the other 2xx status codes
+        HttpStatusCode.Created, //201
+        HttpStatusCode.Accepted, //202
+        HttpStatusCode.NonAuthoritativeInformation, //203
+        HttpStatusCode.NoContent, //204
+        HttpStatusCode.ResetContent, //205
+        HttpStatusCode.PartialContent, //206
+        HttpStatusCode.MultiStatus, //207
+        HttpStatusCode.AlreadyReported, //208
+        HttpStatusCode.IMUsed, //226
 
         // Those cannot be retried based on Event Grid's documentation
         // https://learn.microsoft.com/en-us/azure/event-grid/delivery-and-retry#retry-schedule


### PR DESCRIPTION
<!-- Please fill out any relevant sections and remove those that don't apply -->

## Description of changes
Fixes a bug where messages are retried for delivery if the webhook receiving them responds with a 2xx status code other than 200 OK, when they should not be retried because the webhook indicated success. Eg, 201 No Content or 202 Accepted.

## Breaking changes
No

## Additional checks
<!-- Please check what applies. Note that some of these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Updated the documentation of the project to reflect the changes
- [ ] Added new tests that cover the code changes
